### PR TITLE
Enable circular board outlines to be processed correctly.

### DIFF
--- a/gerber2png.py
+++ b/gerber2png.py
@@ -326,7 +326,7 @@ class GerberData:
 		arc_resolution = 0.00175
 
 #		if not clockwise:
-		if start_angle > end_angle:
+		if start_angle >= end_angle:
 			end_angle += DOUBLE_PI
 	
 		print("Circle at: [", centerx, ", ", centery, "] Radius:", radius)


### PR DESCRIPTION
As per <https://github.com/dgonner/gerber2png.py/issues/3>.